### PR TITLE
Fix pgoapi requests.

### DIFF
--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -106,10 +106,10 @@ class PGoApi:
                            password=None,
                            proxy_config=None,
                            user_agent=None,
-                           timeout=None):
+                           timeout=None,
+                           locale=None):
         if provider == 'ptc':
-            self._auth_provider = AuthPtc(
-                user_agent=user_agent, timeout=timeout)
+            self._auth_provider = AuthPtc(user_agent=user_agent, timeout=timeout, locale=locale)
         elif provider == 'google':
             self._auth_provider = AuthGoogle()
         elif provider is None:

--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -69,7 +69,7 @@ class PGoApi:
             self.set_authentication(provider, oauth2_refresh_token, username,
                                     password, proxy_config)
 
-        self.set_api_endpoint("pgorelease.nianticlabs.com/plfe")
+        self.set_api_endpoint('pgorelease.nianticlabs.com/plfe')
 
         self._position_lat = position_lat
         self._position_lng = position_lng
@@ -78,7 +78,12 @@ class PGoApi:
         self._hash_server_token = None
 
         self._session = requests.session()
-        self._session.headers.update({'User-Agent': 'Niantic App'})
+        self._session.headers.update({
+            'User-Agent': 'Niantic App',
+            'Accept': '*/*',
+            'Content-Type': 'application/binary',
+            'Accept-Encoding': 'identity, gzip'
+        })
         self._session.verify = True
 
         if proxy_config is not None:

--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -80,7 +80,6 @@ class PGoApi:
         self._session = requests.session()
         self._session.headers.update({
             'User-Agent': 'Niantic App',
-            'Accept': '*/*',
             'Content-Type': 'application/binary',
             'Accept-Encoding': 'identity, gzip'
         })

--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -78,11 +78,15 @@ class PGoApi:
         self._hash_server_token = None
 
         self._session = requests.session()
-        self._session.headers.update({
+
+        # requests' Session calls .default_headers() in init, which
+        # makes it set a bunch of default headers, including
+        # 'Connection': 'keep-alive', so we overwrite all of them.
+        self._session.headers = {
             'User-Agent': 'Niantic App',
             'Content-Type': 'application/binary',
             'Accept-Encoding': 'identity, gzip'
-        })
+        }
         self._session.verify = True
 
         if proxy_config is not None:


### PR DESCRIPTION
- Updated User-Agent to a more recent version.
- Updated RPC/PTC requests per the recent MitMs.

Cookie data in the dumps below was removed, these are set via the server's `Set-Cookie`. POST data includes the fields, but all values are removed.

pgoapi:
```
POST /plfe/86/rpc HTTP/1.1
Content-Type: application/binary
Host: pgorelease.nianticlabs.com
User-Agent: Niantic App
Content-Length: 993
Accept-Encoding: identity, gzip
```
PTC:
```
GET https://sso.pokemon.com/sso/login?service=https%3A%2F%2Fsso.pokemon.com%2Fsso%2Foauth2.0%2FcallbackAuthorize&locale=en_US HTTP/1.1
Host: sso.pokemon.com
Accept: */*
Connection: keep-alive
User-Agent: pokemongo/1 CFNetwork/811.5.4 Darwin/16.7.0
Accept-Language: en-us
Accept-Encoding: gzip, deflate
X-Unity-Version: 5.5.1f1

-------------------------------------

POST https://sso.pokemon.com/sso/login?service=http%3A%2F%2Fsso.pokemon.com%2Fsso%2Foauth2.0%2FcallbackAuthorize&locale=en_US HTTP/1.1
Host: sso.pokemon.com
Content-Type: application/x-www-form-urlencoded
User-Agent: pokemongo/1 CFNetwork/811.5.4 Darwin/16.7.0
Connection: keep-alive
Accept: */*
Accept-Language: en-us
Content-Length: 115
Accept-Encoding: gzip, deflate
X-Unity-Version: 5.5.1f1

lt=<censored>&execution=<censored>&_eventId=submit&username=<censored>&password=<censored>

-------------------------------------

POST https://sso.pokemon.com/sso/oauth2.0/accessToken HTTP/1.1
Host: sso.pokemon.com
Content-Type: application/x-www-form-urlencoded
User-Agent: pokemongo/1 CFNetwork/811.5.4 Darwin/16.7.0
Connection: keep-alive
Accept: */*
Accept-Language: en-us
Content-Length: 255
Accept-Encoding: gzip, deflate
X-Unity-Version: 5.5.1f1

client_id=mobile-app_pokemon-go&redirect_uri=https%3a%2f%2fwww.nianticlabs.com%2fpokemongo%2ferror&client_secret=<censored>&grant_type=refresh_token&code=<censored>
```
Finally, added a missing request that wasn't in pgoapi - after `accessToken` the app requests the user's profile:
```
POST https://sso.pokemon.com/sso/oauth2.0/profile HTTP/1.1
Host: sso.pokemon.com
Content-Type: application/x-www-form-urlencoded
User-Agent: pokemongo/1 CFNetwork/811.5.4 Darwin/16.7.0
Connection: keep-alive
Accept: */*
Accept-Language: en-us
Content-Length: 136
Accept-Encoding: gzip, deflate
X-Unity-Version: 5.5.1f1

access_token=<censored>&client_id=mobile-app_pokemon-go&locale=en_US
```